### PR TITLE
Add automatically managed reward roles

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,9 @@ token: "mytoken"
 drop_channels:
   - 357651359379750917
 
+reward_roles:  # Roles given to users once they reach a certain coin threshold
+  100: 518188361547120640
+
 cooldown_time: 20  # seconds for cooldown
 
 recovery_time: 10  # seconds for probability to recover after cooldown expires


### PR DESCRIPTION
Manually checking and adding the reward role becomes annoying after a while, so I thought I'd just let the bot handle this. All changes made here were tested and should work properly.